### PR TITLE
Linter/decorder

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,10 +45,10 @@ linters:
     - bodyclose
     - containedctx
     - contextcheck
+    - decorder
   
   # enable:
   #   - cyclop
-  #   - decorder
   #   - dogsled
   #   - errcheck
   #   - errchkjson

--- a/internal/adapters/github.go
+++ b/internal/adapters/github.go
@@ -14,7 +14,22 @@ import (
 	"github.com/mrlutik/kira2.0/internal/logging"
 )
 
-var log = logging.Log
+type (
+	// gitHubAdapter is a struct to hold the GitHub client
+	gitHubAdapter struct {
+		client *github.Client
+	}
+
+	repository struct {
+		Owner   string
+		Repo    string
+		Version string
+	}
+
+	repositories struct {
+		repos []repository
+	}
+)
 
 const (
 	envGithubTokenVariableName = "GITHUB_TOKEN"
@@ -22,6 +37,8 @@ const (
 	sekaiRepo                  = "sekai"
 	interxRepo                 = "interx"
 )
+
+var log = logging.Log
 
 func MustDownloadBinaries(ctx context.Context, cfg *config.KiraConfig) {
 	repositories := repositories{}
@@ -41,20 +58,6 @@ func MustDownloadBinaries(ctx context.Context, cfg *config.KiraConfig) {
 
 	gitHubAdapter.downloadBinaryFromRepo(ctx, kiraGit, sekaiRepo, cfg.SekaiDebFileName, cfg.SekaiVersion)
 	gitHubAdapter.downloadBinaryFromRepo(ctx, kiraGit, interxRepo, cfg.InterxDebFileName, cfg.InterxVersion)
-}
-
-// gitHubAdapter is a struct to hold the GitHub client
-type gitHubAdapter struct {
-	client *github.Client
-}
-type repository struct {
-	Owner   string
-	Repo    string
-	Version string
-}
-
-type repositories struct {
-	repos []repository
 }
 
 // Add a new Repository to Repositories, version can be = ""

--- a/internal/config/kira.go
+++ b/internal/config/kira.go
@@ -7,53 +7,55 @@ import (
 	vlg "github.com/PeepoFrog/validator-key-gen/MnemonicsGenerator"
 )
 
-// TomlValue represents a configuration value to be updated in the '*.toml' file of the 'sekaid' application.
-type TomlValue struct {
-	Tag   string
-	Name  string
-	Value string
-}
+type (
+	// TomlValue represents a configuration value to be updated in the '*.toml' file of the 'sekaid' application.
+	TomlValue struct {
+		Tag   string
+		Name  string
+		Value string
+	}
 
-// JsonValue represents a configuration value to be updated in the '*.json' file of the 'interx' application
-type JsonValue struct {
-	Key   string // dot-separated keys by nesting
-	Value any
-}
+	// JsonValue represents a configuration value to be updated in the '*.json' file of the 'interx' application
+	JsonValue struct {
+		Key   string // dot-separated keys by nesting
+		Value any
+	}
 
-// KiraConfig is a configuration for sekaid or interx manager.
-type KiraConfig struct {
-	NetworkName         string                 // name of a blockchain name (chain-ID)
-	SekaidHome          string                 // home folder for sekai bin
-	InterxHome          string                 // home folder for interx bin
-	KeyringBackend      string                 // name of keyring backend
-	DockerImageName     string                 // name of a docker image that will be used to create containers for sekai and interx
-	DockerImageVersion  string                 // version of a docker image that will be used to create containers for sekai and interx
-	DockerNetworkName   string                 // the name of docker network that will be create and used for sekaid and interx containers
-	SekaiVersion        string                 // version of sekai binary
-	InterxVersion       string                 // version of interx binary
-	SekaidContainerName string                 // name for sekai container
-	InterxContainerName string                 // name for interx container
-	VolumeName          string                 // the name of a docker's volume that will be SekaidContainerName and InterxContainerName will be using
-	VolumeMoutPath      string                 // mount point in docker volume for containers
-	MnemonicDir         string                 // destination where mnemonics file will be saved
-	RpcPort             string                 // sekaid's rpc port
-	GrpcPort            string                 // sekaid's grpc port
-	P2PPort             string                 // sekaid's p2p port
-	PrometheusPort      string                 // prometheus port
-	InterxPort          string                 // interx endpoint port
-	Moniker             string                 // Moniker
-	SekaiDebFileName    string                 // fileName of sekai deb file
-	InterxDebFileName   string                 // fileName of interx deb file
-	SecretsFolder       string                 // path where mnemonics.env and node keys located
-	TimeBetweenBlocks   time.Duration          // Awaiting time between blocks
-	KiraConfigFilePath  string                 // string to toml km2 config file //default /home/$USER/.config/kira2/kiraConfig.toml
-	ConfigTomlValues    []TomlValue            //`toml:"-"` // List of configs for update
-	Recover             bool                   `toml:"-"` // switch for recover mode
-	MasterMnamonicSet   *vlg.MasterMnemonicSet `toml:"-"`
-	// NOTE Default time of block is ~5 seconds!
-	// Check (m *MonitoringService) GetConsensusInfo method
-	// from cmd/monitoring/main.go
-}
+	// KiraConfig is a configuration for sekaid or interx manager.
+	KiraConfig struct {
+		NetworkName         string                 // name of a blockchain name (chain-ID)
+		SekaidHome          string                 // home folder for sekai bin
+		InterxHome          string                 // home folder for interx bin
+		KeyringBackend      string                 // name of keyring backend
+		DockerImageName     string                 // name of a docker image that will be used to create containers for sekai and interx
+		DockerImageVersion  string                 // version of a docker image that will be used to create containers for sekai and interx
+		DockerNetworkName   string                 // the name of docker network that will be create and used for sekaid and interx containers
+		SekaiVersion        string                 // version of sekai binary
+		InterxVersion       string                 // version of interx binary
+		SekaidContainerName string                 // name for sekai container
+		InterxContainerName string                 // name for interx container
+		VolumeName          string                 // the name of a docker's volume that will be SekaidContainerName and InterxContainerName will be using
+		VolumeMoutPath      string                 // mount point in docker volume for containers
+		MnemonicDir         string                 // destination where mnemonics file will be saved
+		RpcPort             string                 // sekaid's rpc port
+		GrpcPort            string                 // sekaid's grpc port
+		P2PPort             string                 // sekaid's p2p port
+		PrometheusPort      string                 // prometheus port
+		InterxPort          string                 // interx endpoint port
+		Moniker             string                 // Moniker
+		SekaiDebFileName    string                 // fileName of sekai deb file
+		InterxDebFileName   string                 // fileName of interx deb file
+		SecretsFolder       string                 // path where mnemonics.env and node keys located
+		TimeBetweenBlocks   time.Duration          // Awaiting time between blocks
+		KiraConfigFilePath  string                 // string to toml km2 config file //default /home/$USER/.config/kira2/kiraConfig.toml
+		ConfigTomlValues    []TomlValue            //`toml:"-"` // List of configs for update
+		Recover             bool                   `toml:"-"` // switch for recover mode
+		MasterMnamonicSet   *vlg.MasterMnemonicSet `toml:"-"`
+		// NOTE Default time of block is ~5 seconds!
+		// Check (m *MonitoringService) GetConsensusInfo method
+		// from cmd/monitoring/main.go
+	}
+)
 
 func (cfg *KiraConfig) GetVolumeMountPoint() string {
 	return fmt.Sprintf("%s:%s", cfg.VolumeName, cfg.VolumeMoutPath)

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -14,22 +14,23 @@ import (
 	"github.com/mrlutik/kira2.0/internal/osutils"
 )
 
-var log = logging.Log
+type (
+	DockerConfig struct {
+		Host       string `json:"Host"`
+		APIVersion string `json:"APIVersion,omitempty"`
+		CertPath   string `json:"CertPath"`
+		CacertPath string `json:"CacertPath"`
+		KeyPath    string `json:"KeyPath"`
+	}
+	DockerManager struct {
+		Cli *client.Client
+	}
+)
 
-type DockerConfig struct {
-	Host       string `json:"Host"`
-	APIVersion string `json:"APIVersion,omitempty"`
-	CertPath   string `json:"CertPath"`
-	CacertPath string `json:"CacertPath"`
-	KeyPath    string `json:"KeyPath"`
-}
+var log = logging.Log
 
 func (dm *DockerConfig) SetVersion(version string) {
 	dm.APIVersion = version
-}
-
-type DockerManager struct {
-	Cli *client.Client
 }
 
 // NewDockerManager creates a new DockerManager instance based on the provided configuration.

--- a/internal/firewall/firewallManager/firewallHandler/firewallHandler.go
+++ b/internal/firewall/firewallManager/firewallHandler/firewallHandler.go
@@ -16,18 +16,14 @@ import (
 	"github.com/mrlutik/kira2.0/internal/osutils"
 )
 
-var log = logging.Log
-
-//	func NewFirewallHandler(dockerManager *docker.DockerManager, firewalldController *firewallController.FirewalldController) *FirewallHandler {
-//		return &FirewallHandler{firewalldController: firewalldController, dockerManager: dockerManager}
-//	}
-func NewFirewallHandler(firewalldController *firewallController.FirewalldController) *FirewallHandler {
-	return &FirewallHandler{firewalldController: firewalldController}
-}
-
 type FirewallHandler struct {
 	firewalldController *firewallController.FirewalldController
-	// dockerManager       *docker.DockerManager
+}
+
+var log = logging.Log
+
+func NewFirewallHandler(firewalldController *firewallController.FirewalldController) *FirewallHandler {
+	return &FirewallHandler{firewalldController: firewalldController}
 }
 
 func (fh *FirewallHandler) OpenPorts(portsToOpen []types.Port, zoneName string) error {

--- a/internal/firewall/firewallManager/firewallManager.go
+++ b/internal/firewall/firewallManager/firewallManager.go
@@ -9,25 +9,27 @@ import (
 	"github.com/mrlutik/kira2.0/internal/docker"
 	"github.com/mrlutik/kira2.0/internal/firewall/firewallController"
 	"github.com/mrlutik/kira2.0/internal/firewall/firewallManager/firewallHandler"
-	"github.com/mrlutik/kira2.0/internal/types"
-
-	// D:\Coding\Go\KIRA\kira2.0\kira2.0\internal\firewall\firewallManager\firewallHandlers\firewallHandlers.go
 	"github.com/mrlutik/kira2.0/internal/logging"
 	"github.com/mrlutik/kira2.0/internal/osutils"
+	"github.com/mrlutik/kira2.0/internal/types"
 )
 
-type FirewallManager struct {
-	FirewalldController *firewallController.FirewalldController
-	DockerManager       *docker.DockerManager
-	FirewallHandler     *firewallHandler.FirewallHandler
-	FirewallConfig      *FirewallConfig
-	KiraConfig          *config.KiraConfig
-}
+type (
+	FirewallManager struct {
+		FirewalldController *firewallController.FirewalldController
+		DockerManager       *docker.DockerManager
+		FirewallHandler     *firewallHandler.FirewallHandler
+		FirewallConfig      *FirewallConfig
+		KiraConfig          *config.KiraConfig
+	}
 
-type FirewallConfig struct {
-	ZoneName    string
-	PortsToOpen []types.Port
-}
+	FirewallConfig struct {
+		ZoneName    string
+		PortsToOpen []types.Port
+	}
+)
+
+var log = logging.Log
 
 // port range 0-65535
 // type udp or tcp
@@ -54,8 +56,6 @@ func NewFirewallManager(dockerManager *docker.DockerManager, kiraCfg *config.Kir
 
 	return &FirewallManager{FirewalldController: c, DockerManager: dockerManager, FirewallHandler: h, FirewallConfig: cfg, KiraConfig: kiraCfg}
 }
-
-var log = logging.Log
 
 func (fm *FirewallManager) CheckFirewallSetUp(ctx context.Context) (bool, error) {
 	_, err := exec.LookPath("firewall-cmd")
@@ -134,11 +134,6 @@ func (fm *FirewallManager) SetUpFirewall(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("%s\n%w", o, err)
 	}
-	// log.Infof("Closing all ports\n")
-	// o, err = fm.FirewalldController.DropAllPorts()
-	// if err != nil {
-	// 	return fmt.Errorf("%s\n%w", o, err)
-	// }
 
 	log.Infof("Checking ports %+v \n", fm.FirewallConfig.PortsToOpen)
 	err = fm.FirewallHandler.CheckPorts(fm.FirewallConfig.PortsToOpen)
@@ -199,7 +194,7 @@ func (fm *FirewallManager) SetUpFirewall(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("%s\n%w", o, err)
 	}
-	// os.Exit(1)
+
 	// adding docker to the zone and enabling routing
 	log.Infof("Adding docker0 interface to the zone and enabling routing\n")
 	o, err = fm.FirewalldController.AddInterfaceToTheZone("docker0", fm.FirewallConfig.ZoneName)
@@ -210,10 +205,7 @@ func (fm *FirewallManager) SetUpFirewall(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("%s\n%w", o, err)
 	}
-	// o, err = fm.FirewalldController.EnableDockerRouting("docker0")
-	// if err != nil {
-	// 	return fmt.Errorf("%s\n%w", o, err)
-	// }
+
 	log.Infof("Reloading firewall\n")
 	o, err = fm.FirewalldController.ReloadFirewall()
 	if err != nil {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -5,15 +5,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func init() {
-	Log = InitLogger(Hooks, "panic")
-}
-
 var (
 	Log            *logrus.Logger
 	Hooks          = []logrus.Hook{&hooks.ColorHook{}}
 	ValidLogLevels = []string{"trace", "debug", "info", "warn", "error", "fatal", "panic"}
 )
+
+func init() {
+	Log = InitLogger(Hooks, "panic")
+}
 
 func InitLogger(h []logrus.Hook, logLevelStr string) *logrus.Logger {
 	log := logrus.New()

--- a/internal/manager/cli/commands/firewall/blacklist/blacklist.go
+++ b/internal/manager/cli/commands/firewall/blacklist/blacklist.go
@@ -12,17 +12,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var log = logging.Log
-
 const (
 	use   = "blacklist"
 	short = "subcommand for blacklisting ips"
 	long  = `subcommand for adding to blacklist or removing from blacklist specific ips
-example: 
+	example: 
 	km2 firewall blacklist --ip 8.8.8.8 --add --log-level debug
 	
 	km2 firewall blacklist --ip 8.8.8.8 --remove --log-level debug`
 )
+
+var log = logging.Log
 
 func Blacklist() *cobra.Command {
 	closePortCmd := &cobra.Command{

--- a/internal/manager/cli/commands/firewall/closePort/closePort.go
+++ b/internal/manager/cli/commands/firewall/closePort/closePort.go
@@ -11,13 +11,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var log = logging.Log
-
 const (
 	use   = "close-port"
 	short = "subcommand for port closing"
 	long  = "long description"
 )
+
+var log = logging.Log
 
 func ClosePort() *cobra.Command {
 	closePortCmd := &cobra.Command{

--- a/internal/manager/cli/commands/firewall/firewall.go
+++ b/internal/manager/cli/commands/firewall/firewall.go
@@ -16,13 +16,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var log = logging.Log
-
 const (
 	use   = "firewall"
 	short = "Seting up firewalld"
 	long  = "Seting up firewalld"
 )
+
+var log = logging.Log
 
 func Firewall() *cobra.Command {
 	log.Info("Adding `firewall` command...")

--- a/internal/manager/cli/commands/firewall/openPort/openPort.go
+++ b/internal/manager/cli/commands/firewall/openPort/openPort.go
@@ -11,13 +11,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var log = logging.Log
-
 const (
 	use   = "open-port"
 	short = "subcommand for port opening"
 	long  = "long description"
 )
+
+var log = logging.Log
 
 func OpenPort() *cobra.Command {
 	openPortCmd := &cobra.Command{

--- a/internal/manager/cli/commands/firewall/whitelist/whitelist.go
+++ b/internal/manager/cli/commands/firewall/whitelist/whitelist.go
@@ -12,17 +12,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var log = logging.Log
-
 const (
 	use   = "whitelist"
 	short = "subcommand for whitelisting ips"
 	long  = `subcommand for adding to whitelist or removing from whitelist specific ips
-example: 
+	example: 
 	km2 firewall whitelist --ip 8.8.8.8 --add --log-level debug
 	
 	km2 firewall whitelist --ip 8.8.8.8 --remove --log-level debug`
 )
+
+var log = logging.Log
 
 func Whitelist() *cobra.Command {
 	closePortCmd := &cobra.Command{

--- a/internal/manager/cli/commands/init/init.go
+++ b/internal/manager/cli/commands/init/init.go
@@ -7,13 +7,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var log = logging.Log
-
 const (
 	use   = "init"
 	short = "init your node"
 	long  = "init your node with creating new network or joining to existing one"
 )
+
+var log = logging.Log
 
 func Init() *cobra.Command {
 	log.Info("Adding `firewall` command...")

--- a/internal/manager/cli/commands/init/join/join.go
+++ b/internal/manager/cli/commands/init/join/join.go
@@ -19,21 +19,21 @@ import (
 )
 
 const (
+	// Command information
 	use   = "join"
 	short = "Join to network"
 	long  = "Join to existing network"
-)
 
-const (
+	// Flags naming
 	sekaiVersionFlag  = "sekai-version"
 	interxVersionFlag = "interx-version"
+
+	// Regular expression to match IPv4 and IPv6 addresses.
+	ipRegex = `^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$|^(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}$`
+
+	// Regular expression to match valid port numbers (from 1 to 65535).
+	portRegex = `^([1-9]\d{0,4}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$`
 )
-
-// Regular expression to match IPv4 and IPv6 addresses.
-const ipRegex = `^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$|^(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}$`
-
-// Regular expression to match valid port numbers (from 1 to 65535).
-const portRegex = `^([1-9]\d{0,4}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$`
 
 var (
 	log     = logging.Log

--- a/internal/manager/cli/commands/init/new/new.go
+++ b/internal/manager/cli/commands/init/new/new.go
@@ -16,20 +16,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	log     = logging.Log
-	recover bool
-)
-
 const (
+	// Command information
 	use   = "new"
 	short = "Create new blockchain network"
 	long  = "Create new blockchain network from genesis file"
-)
 
-const (
+	// Flags naming
 	sekaiVersionFlag  = "sekai-version"
 	interxVersionFlag = "interx-version"
+)
+
+var (
+	log     = logging.Log
+	recover bool
 )
 
 func New() *cobra.Command {

--- a/internal/manager/cli/commands/maintenance/mainteance.go
+++ b/internal/manager/cli/commands/maintenance/mainteance.go
@@ -11,13 +11,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var log = logging.Log
-
 const (
 	use   = "maintenance"
 	short = "command for maintenance mode"
 	long  = "command for maintenance mode: pause for maintenance, unpause, and activate if validator was deactivated"
 )
+
+var log = logging.Log
 
 func Maintenance() *cobra.Command {
 	log.Info("Adding `maintenance` command...")

--- a/internal/manager/interx.go
+++ b/internal/manager/interx.go
@@ -19,8 +19,6 @@ import (
 	"github.com/mrlutik/kira2.0/internal/types"
 )
 
-const interxProcessName = "interx"
-
 // InterxManager represents a manager for Interx container and its associated configurations.
 type InterxManager struct {
 	ContainerConfig     *container.Config
@@ -29,6 +27,8 @@ type InterxManager struct {
 	containerManager    *docker.ContainerManager
 	config              *config.KiraConfig
 }
+
+const interxProcessName = "interx"
 
 // NewInterxManager returns configured InterxManager.
 func NewInterxManager(containerManager *docker.ContainerManager, config *config.KiraConfig) (*InterxManager, error) {

--- a/internal/manager/utils/utils.go
+++ b/internal/manager/utils/utils.go
@@ -98,13 +98,6 @@ func (h *HelperManager) AwaitNextBlock(ctx context.Context, timeout time.Duratio
 	}
 }
 
-// nodeStatus is a structure which represents the partial response from `sekaid status`
-type nodeStatus struct {
-	SyncInfo struct {
-		LatestBlockHeight string `json:"latest_block_height"`
-	} `json:"SyncInfo"`
-}
-
 // getBlockHeight retrieves the latest block height from the sekaid node.
 // It executes the "sekaid status" command in the specified container
 // and parses the JSON output to extract the block height.
@@ -119,7 +112,11 @@ func (h *HelperManager) getBlockHeight(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("getting '%s' error: %s", cmd, err)
 	}
 
-	var status nodeStatus
+	var status struct { // anon structure which represents the partial response from `sekaid status`
+		SyncInfo struct {
+			LatestBlockHeight string `json:"latest_block_height"`
+		} `json:"SyncInfo"`
+	}
 	err = json.Unmarshal(statusOutput, &status)
 	if err != nil {
 		log.Errorf("Parsing JSON output of '%s' error: %s", cmd, err)

--- a/internal/monitoring/docker.go
+++ b/internal/monitoring/docker.go
@@ -6,12 +6,34 @@ import (
 	"time"
 )
 
-// DockerNetworkInfo contains needed information about a Docker network.
-type DockerNetwrokInfo struct {
-	Name      string
-	IpAddress string
-	Subnet    string
-}
+type (
+	// DockerNetworkInfo contains needed information about a Docker network.
+	DockerNetwrokInfo struct {
+		Name      string
+		IpAddress string
+		Subnet    string
+	}
+
+	// PortBinding contains the port binding information for a Docker container.
+	PortBinding struct {
+		HostPort      string
+		ContainerPort string
+	}
+
+	// ContainerInfo contains information about a Docker container.
+	ContainerInfo struct {
+		ID          string
+		State       string
+		Health      string
+		Paused      bool
+		Restarting  bool
+		StartingAt  time.Time
+		FinishedAt  time.Time
+		Hostname    string
+		IP          string
+		PortBinding []PortBinding
+	}
+)
 
 // GetDockerNetwork retrieves information about a Docker network.
 // It queries the Docker daemon to obtain a list of network resources and searches for the specified network by name.
@@ -34,26 +56,6 @@ func (m *MonitoringService) GetDockerNetwork(ctx context.Context, networkName st
 		}
 	}
 	return nil, fmt.Errorf("the network '%s' is not available", networkName)
-}
-
-// PortBinding contains the port binding information for a Docker container.
-type PortBinding struct {
-	HostPort      string
-	ContainerPort string
-}
-
-// ContainerInfo contains information about a Docker container.
-type ContainerInfo struct {
-	ID          string
-	State       string
-	Health      string
-	Paused      bool
-	Restarting  bool
-	StartingAt  time.Time
-	FinishedAt  time.Time
-	Hostname    string
-	IP          string
-	PortBinding []PortBinding
 }
 
 // GetContainerInfo retrieves information about a Docker container and its network bindings.

--- a/internal/monitoring/hardware.go
+++ b/internal/monitoring/hardware.go
@@ -11,15 +11,31 @@ import (
 	"github.com/shirou/gopsutil/v3/mem"
 )
 
+type (
+	// RamUsageInfo represents information about RAM usage.
+	RamUsageInfo struct {
+		TotalGB float64
+		FreeGB  float64
+		UsedGB  float64
+	}
+
+	// DiskUsageInfo represents information about disk usage.
+	DiskUsageInfo struct {
+		TotalGB uint64
+		FreeGB  uint64
+		UsedGB  uint64
+	}
+)
+
 func (m *MonitoringService) GetCPULoadPercentage() (float64, error) {
 	return getCPULoadPercentage()
 }
 
-func (m *MonitoringService) GetRAMUsage() (*ramUsageInfo, error) {
+func (m *MonitoringService) GetRAMUsage() (*RamUsageInfo, error) {
 	return getRAMUsage()
 }
 
-func (m *MonitoringService) GetDiskUsage() (*diskUsageInfo, error) {
+func (m *MonitoringService) GetDiskUsage() (*DiskUsageInfo, error) {
 	return getDiskUsage()
 }
 
@@ -44,15 +60,8 @@ func getCPULoadPercentage() (float64, error) {
 	return percent[0], nil
 }
 
-// ramUsageInfo represents information about RAM usage.
-type ramUsageInfo struct {
-	TotalGB float64
-	FreeGB  float64
-	UsedGB  float64
-}
-
 // getRAMUsage returns the RAM usage information.
-func getRAMUsage() (*ramUsageInfo, error) {
+func getRAMUsage() (*RamUsageInfo, error) {
 	log.Infoln("Getting RAM usage info")
 
 	virtualMemory, err := mem.VirtualMemory()
@@ -61,22 +70,15 @@ func getRAMUsage() (*ramUsageInfo, error) {
 		return nil, err
 	}
 
-	return &ramUsageInfo{
+	return &RamUsageInfo{
 		TotalGB: float64(virtualMemory.Total) / gigabyte,
 		FreeGB:  float64(virtualMemory.Free) / gigabyte,
 		UsedGB:  float64(virtualMemory.Used) / gigabyte,
 	}, nil
 }
 
-// diskUsageInfo represents information about disk usage.
-type diskUsageInfo struct {
-	TotalGB uint64
-	FreeGB  uint64
-	UsedGB  uint64
-}
-
 // getDiskUsage returns the disk usage information.
-func getDiskUsage() (*diskUsageInfo, error) {
+func getDiskUsage() (*DiskUsageInfo, error) {
 	log.Infoln("Getting disk usage info")
 
 	var stat syscall.Statfs_t
@@ -89,7 +91,7 @@ func getDiskUsage() (*diskUsageInfo, error) {
 	total := stat.Blocks * uint64(stat.Bsize)
 	available := stat.Bavail * uint64(stat.Bsize)
 
-	return &diskUsageInfo{
+	return &DiskUsageInfo{
 		TotalGB: total / gigabyte,
 		FreeGB:  available / gigabyte,
 		UsedGB:  (total - available) / gigabyte,

--- a/internal/monitoring/interx.go
+++ b/internal/monitoring/interx.go
@@ -10,19 +10,48 @@ import (
 	"github.com/mrlutik/kira2.0/internal/types"
 )
 
-// ValopersInfo represents the information about Valopers returned by the Valopers API.
-type ResponseValopers struct {
-	Status struct {
-		ActiveValidators  int `json:"active_validators"`
-		TotalValidators   int `json:"total_validators"`
-		WaitingValidators int `json:"waiting_validators"`
-	} `json:"status"`
+type (
+	// ResponseValopers represents the information about Valopers returned by the Valopers API.
+	ResponseValopers struct {
+		Status struct {
+			ActiveValidators  int `json:"active_validators"`
+			TotalValidators   int `json:"total_validators"`
+			WaitingValidators int `json:"waiting_validators"`
+		} `json:"status"`
 
-	Validators []struct {
-		Top     string `json:"top"`
-		Address string `json:"address"`
-	} `json:"validators"`
-}
+		Validators []struct {
+			Top     string `json:"top"`
+			Address string `json:"address"`
+		} `json:"validators"`
+	}
+
+	// InterxInfo represents the information about Interx.
+	InterxInfo struct {
+		NodeID            string
+		LatestBlockHeight int
+		LatestBlockTime   time.Time
+		CatchingUp        bool
+	}
+
+	// ValopersInfo represents the information about Valopers.
+	ValopersInfo struct {
+		ActiveValidators  int
+		TotalValidators   int
+		WaitingValidators int
+	}
+
+	// ResponseBlockStats represents the JSON needed response structure for the BlockStats API.
+	ResponseBlockStats struct {
+		AverageBlockTime float64 `json:"average_block_time"`
+		ConsensusStopped bool    `json:"consensus_stopped"`
+	}
+
+	// ConsensusInfo represents the most needed consensus information.
+	ConsensusInfo struct {
+		BlockTime        float64
+		ConsensusStopped bool
+	}
+)
 
 // doGetValopersQuery performs the Valopers query using the provided HTTP client,
 // interxPort, and timeout duration, and returns the parsed response or an error.
@@ -34,13 +63,6 @@ func doGetValopersQuery(ctx context.Context, httpClient *http.Client, interxPort
 	}
 
 	return &response, nil
-}
-
-// ValopersInfo represents the information about Valopers.
-type ValopersInfo struct {
-	ActiveValidators  int
-	TotalValidators   int
-	WaitingValidators int
 }
 
 // GetValopersInfo retrieves the information about Valopers using the provided
@@ -78,12 +100,6 @@ func (m *MonitoringService) GetTopForValidator(ctx context.Context, interxPort, 
 	return "", fmt.Errorf("can't find validator address '%s'", validatorAddress)
 }
 
-// ResponseBlockStats represents the JSON needed response structure for the BlockStats API.
-type ResponseBlockStats struct {
-	AverageBlockTime float64 `json:"average_block_time"`
-	ConsensusStopped bool    `json:"consensus_stopped"`
-}
-
 // doGetConsensusQuery performs the Consensus query using the provided HTTP client,
 // interxPort, and timeout duration, and returns the parsed response or an error.
 func doGetConsensusQuery(ctx context.Context, httpClient *http.Client, interxPort string, timeout time.Duration) (*ResponseBlockStats, error) {
@@ -94,12 +110,6 @@ func doGetConsensusQuery(ctx context.Context, httpClient *http.Client, interxPor
 	}
 
 	return &response, nil
-}
-
-// ConsensusInfo represents the needed consensus information.
-type ConsensusInfo struct {
-	BlockTime        float64
-	ConsensusStopped bool
 }
 
 // GetConsensusInfo retrieves the consensus information using the provided context
@@ -127,14 +137,6 @@ func doGetInterxStatusQuery(ctx context.Context, httpClient *http.Client, interx
 	}
 
 	return response, nil
-}
-
-// InterxInfo represents the information about Interx.
-type InterxInfo struct {
-	NodeID            string
-	LatestBlockHeight int
-	LatestBlockTime   time.Time
-	CatchingUp        bool
 }
 
 // GetInterxInfo retrieves the information about Interx using the provided context

--- a/internal/monitoring/monitoring.go
+++ b/internal/monitoring/monitoring.go
@@ -14,19 +14,19 @@ import (
 	"github.com/mrlutik/kira2.0/internal/logging"
 )
 
-const (
-	gigabyte        = 1024 * 1024 * 1024
-	getQueryTimeout = time.Second
-)
-
-var log = logging.Log
-
 // MonitoringService represents a monitoring service that interacts with the Docker and HTTP clients.
 type MonitoringService struct {
 	dockerManager    *docker.DockerManager
 	containerManager *docker.ContainerManager
 	httpClient       *http.Client
 }
+
+const (
+	gigabyte        = 1024 * 1024 * 1024
+	getQueryTimeout = time.Second
+)
+
+var log = logging.Log
 
 func NewMonitoringService(dm *docker.DockerManager, cm *docker.ContainerManager) *MonitoringService {
 	return &MonitoringService{

--- a/internal/monitoring/sekaid.go
+++ b/internal/monitoring/sekaid.go
@@ -13,32 +13,6 @@ import (
 	"github.com/mrlutik/kira2.0/internal/types"
 )
 
-// GetValidatorAddress retrieves the address of the validator using the specified
-// sekaid container name, keyring backend, and home directory.
-func (m *MonitoringService) GetValidatorAddress(ctx context.Context, sekaidContainerName, keyringBackend, homeDir string) (string, error) {
-	cmd := fmt.Sprintf("sekaid keys show validator -a --keyring-backend=%s --home=%s", keyringBackend, homeDir)
-	output, err := m.containerManager.ExecCommandInContainer(ctx, sekaidContainerName, []string{"bash", "-c", cmd})
-	if err != nil {
-		log.Errorf("Can't execute command '%s', error: '%s'", cmd, err)
-		return "", err
-	}
-
-	result := strings.ReplaceAll(string(output), "\n", "")
-	return result, nil
-}
-
-// doGetSekaidStatusQuery performs the Sekaid status query using the provided HTTP client,
-// sekaid port, and timeout duration, and returns the parsed response or an error.
-func doGetSekaidStatusQuery(ctx context.Context, httpClient *http.Client, sekaidPort string, timeout time.Duration) (*types.ResponseSekaidStatus, error) {
-	var response *types.ResponseSekaidStatus
-	err := doHTTPGetQuery(ctx, httpClient, sekaidPort, timeout, "status", &response)
-	if err != nil {
-		return nil, err
-	}
-
-	return response, nil
-}
-
 // SekaidInfo represents the needed information about Sekaid.
 type SekaidInfo struct {
 	NodeID            string
@@ -69,4 +43,30 @@ func (m *MonitoringService) GetSekaidInfo(ctx context.Context, sekaidPort string
 		LatestBlockTime:   response.Result.SyncInfo.LatestBlockTime,
 		CatchingUp:        response.Result.SyncInfo.CatchingUp,
 	}, nil
+}
+
+// GetValidatorAddress retrieves the address of the validator using the specified
+// sekaid container name, keyring backend, and home directory.
+func (m *MonitoringService) GetValidatorAddress(ctx context.Context, sekaidContainerName, keyringBackend, homeDir string) (string, error) {
+	cmd := fmt.Sprintf("sekaid keys show validator -a --keyring-backend=%s --home=%s", keyringBackend, homeDir)
+	output, err := m.containerManager.ExecCommandInContainer(ctx, sekaidContainerName, []string{"bash", "-c", cmd})
+	if err != nil {
+		log.Errorf("Can't execute command '%s', error: '%s'", cmd, err)
+		return "", err
+	}
+
+	result := strings.ReplaceAll(string(output), "\n", "")
+	return result, nil
+}
+
+// doGetSekaidStatusQuery performs the Sekaid status query using the provided HTTP client,
+// sekaid port, and timeout duration, and returns the parsed response or an error.
+func doGetSekaidStatusQuery(ctx context.Context, httpClient *http.Client, sekaidPort string, timeout time.Duration) (*types.ResponseSekaidStatus, error) {
+	var response *types.ResponseSekaidStatus
+	err := doHTTPGetQuery(ctx, httpClient, sekaidPort, timeout, "status", &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }

--- a/internal/systemd/manager.go
+++ b/internal/systemd/manager.go
@@ -10,13 +10,13 @@ import (
 	"github.com/mrlutik/kira2.0/internal/logging"
 )
 
-var log = logging.Log
-
 type ServiceManager struct {
 	connection  *dbus.Conn
 	serviceName string
 	modeAction  string
 }
+
+var log = logging.Log
 
 func NewServiceManager(ctx context.Context, serviceName, mode string) (*ServiceManager, error) {
 	conn, err := dbus.NewWithContext(ctx)

--- a/internal/types/constants.go
+++ b/internal/types/constants.go
@@ -1,15 +1,13 @@
 package types
 
-const KiraVersion = "v0.0.50"
-
 const (
+	KiraVersion = "v0.0.50"
+
 	ValidatorAccountName = "validator"
 	GenesisFileName      = "genesis.json"
-)
 
-// constants of validatorStatus
-// warning validator status from sekaid comes in uper case format
-const (
+	// constants of validatorStatus
+	// warning validator status from sekaid comes in upper case format
 	Active   = "active"
 	Paused   = "paused"
 	Inactive = "inactive"

--- a/internal/types/interx.go
+++ b/internal/types/interx.go
@@ -3,18 +3,20 @@ package types
 import "time"
 
 // ResponseInterxStatus represents the JSON response structure for the Interx `/api/status` query.
-type ResponseInterxStatus struct {
-	NodeInfo struct {
-		ID string `json:"id"`
-	} `json:"node_info"`
-	SyncInfo struct {
-		LatestBlockHeight string    `json:"latest_block_height"`
-		LatestBlockTime   time.Time `json:"latest_block_time"`
-		CatchingUp        bool      `json:"catching_up"`
-	} `json:"sync_info"`
-}
+type (
+	ResponseInterxStatus struct {
+		NodeInfo struct {
+			ID string `json:"id"`
+		} `json:"node_info"`
+		SyncInfo struct {
+			LatestBlockHeight string    `json:"latest_block_height"`
+			LatestBlockTime   time.Time `json:"latest_block_time"`
+			CatchingUp        bool      `json:"catching_up"`
+		} `json:"sync_info"`
+	}
 
-// ResponseCheckSum represents the JSON response structure for the Interx `/api/gensum` query.
-type ResponseCheckSum struct {
-	Checksum string `json:"checksum"`
-}
+	// ResponseCheckSum represents the JSON response structure for the Interx `/api/gensum` query.
+	ResponseCheckSum struct {
+		Checksum string `json:"checksum"`
+	}
+)

--- a/internal/types/sekaid.go
+++ b/internal/types/sekaid.go
@@ -6,52 +6,54 @@ import (
 )
 
 // ResponseSekaidStatus represents the JSON response structure for the Sekaid `/status` query.
-type ResponseSekaidStatus struct {
-	Result struct {
-		NodeInfo struct {
-			ID      string `json:"id"`
-			Network string `json:"network"`
-		} `json:"node_info"`
-		SyncInfo struct {
-			LatestBlockHeight string    `json:"latest_block_height"`
-			LatestBlockTime   time.Time `json:"latest_block_time"`
-			CatchingUp        bool      `json:"catching_up"`
-		} `json:"sync_info"`
-	} `json:"result"`
-}
+type (
+	ResponseSekaidStatus struct {
+		Result struct {
+			NodeInfo struct {
+				ID      string `json:"id"`
+				Network string `json:"network"`
+			} `json:"node_info"`
+			SyncInfo struct {
+				LatestBlockHeight string    `json:"latest_block_height"`
+				LatestBlockTime   time.Time `json:"latest_block_time"`
+				CatchingUp        bool      `json:"catching_up"`
+			} `json:"sync_info"`
+		} `json:"result"`
+	}
 
-// ResponseChunkedGenesis represents the JSON response structure for the Sekaid `/chunked_genesis` query.
-type ResponseChunkedGenesis struct {
-	Result struct {
-		Chunk json.Number `json:"chunk"`
-		Total json.Number `json:"total"`
-		Data  string      `json:"data"`
-	} `json:"result"`
-}
+	// ResponseChunkedGenesis represents the JSON response structure for the Sekaid `/chunked_genesis` query.
+	ResponseChunkedGenesis struct {
+		Result struct {
+			Chunk json.Number `json:"chunk"`
+			Total json.Number `json:"total"`
+			Data  string      `json:"data"`
+		} `json:"result"`
+	}
 
-// ResponseBlock represents the JSON response structure for the Sekaid `/block` query.
-type ResponseBlock struct {
-	Result struct {
-		BlockID struct {
-			Hash string `json:"hash"`
-		} `json:"block_id"`
-		Block struct {
-			Header struct {
-				Height string `json:"height"`
-			} `json:"header"`
-		} `json:"block"`
-	} `json:"result"`
-}
+	// ResponseBlock represents the JSON response structure for the Sekaid `/block` query.
+	ResponseBlock struct {
+		Result struct {
+			BlockID struct {
+				Hash string `json:"hash"`
+			} `json:"block_id"`
+			Block struct {
+				Header struct {
+					Height string `json:"height"`
+				} `json:"header"`
+			} `json:"block"`
+		} `json:"result"`
+	}
 
-// sekaid query customstaking validator --addr=kira19p8h9kwvrwgeu80c89ctvhwx7w3fc7r7rh32an --output json
-type ValidatorStatus struct {
-	ValKey string                `json:"val_key"`
-	PubKey validatorStatusPubKey `json:"pub_key"`
-	Status string                `json:"status"`
-	Rank   string                `json:"rank"`
-	Streak string                `json:"streak"`
-}
-type validatorStatusPubKey struct {
-	Type string `json:"@type"`
-	Key  string `json:"key"`
-}
+	// sekaid query customstaking validator --addr=kira19p8h9kwvrwgeu80c89ctvhwx7w3fc7r7rh32an --output json
+	ValidatorStatus struct {
+		ValKey string                `json:"val_key"`
+		PubKey validatorStatusPubKey `json:"pub_key"`
+		Status string                `json:"status"`
+		Rank   string                `json:"rank"`
+		Streak string                `json:"streak"`
+	}
+	validatorStatusPubKey struct {
+		Type string `json:"@type"`
+		Key  string `json:"key"`
+	}
+)

--- a/internal/types/status.go
+++ b/internal/types/status.go
@@ -44,58 +44,60 @@ package types
 //		  }
 //		}
 //	   }
-type Status struct {
-	Jsonrpc string `json:"jsonrpc"`
-	ID      int    `json:"id"`
-	Result  Result `json:"result"`
-}
+type (
+	Status struct {
+		Jsonrpc string `json:"jsonrpc"`
+		ID      int    `json:"id"`
+		Result  Result `json:"result"`
+	}
 
-type Result struct {
-	NodeInfo      NodeInfo      `json:"node_info"`
-	SyncInfo      SyncInfo      `json:"sync_info"`
-	ValidatorInfo ValidatorInfo `json:"validator_info"`
-}
+	Result struct {
+		NodeInfo      NodeInfo      `json:"node_info"`
+		SyncInfo      SyncInfo      `json:"sync_info"`
+		ValidatorInfo ValidatorInfo `json:"validator_info"`
+	}
 
-type NodeInfo struct {
-	ProtocolVersion ProtocolVersion `json:"protocol_version"`
-	ID              string          `json:"id"`
-	ListenAddr      string          `json:"listen_addr"`
-	Network         string          `json:"network"`
-	Version         string          `json:"version"`
-	Channels        string          `json:"channels"`
-	Moniker         string          `json:"moniker"`
-	Other           Other           `json:"other"`
-}
+	NodeInfo struct {
+		ProtocolVersion ProtocolVersion `json:"protocol_version"`
+		ID              string          `json:"id"`
+		ListenAddr      string          `json:"listen_addr"`
+		Network         string          `json:"network"`
+		Version         string          `json:"version"`
+		Channels        string          `json:"channels"`
+		Moniker         string          `json:"moniker"`
+		Other           Other           `json:"other"`
+	}
 
-type Other struct {
-	TxIndex    string `json:"tx_index"`
-	RPCAddress string `json:"rpc_address"`
-}
+	Other struct {
+		TxIndex    string `json:"tx_index"`
+		RPCAddress string `json:"rpc_address"`
+	}
 
-type ProtocolVersion struct {
-	P2P   string `json:"p2p"`
-	Block string `json:"block"`
-	App   string `json:"app"`
-}
+	ProtocolVersion struct {
+		P2P   string `json:"p2p"`
+		Block string `json:"block"`
+		App   string `json:"app"`
+	}
 
-type SyncInfo struct {
-	LatestBlockHash     string `json:"latest_block_hash"`
-	LatestAppHash       string `json:"latest_app_hash"`
-	LatestBlockHeight   string `json:"latest_block_height"`
-	LatestBlockTime     string `json:"latest_block_time"`
-	EarliestBlockHash   string `json:"earliest_block_hash"`
-	EarliestAppHash     string `json:"earliest_app_hash"`
-	EarliestBlockHeight string `json:"earliest_block_height"`
-	EarliestBlockTime   string `json:"earliest_block_time"`
-	CatchingUp          bool   `json:"catching_up"`
-}
+	SyncInfo struct {
+		LatestBlockHash     string `json:"latest_block_hash"`
+		LatestAppHash       string `json:"latest_app_hash"`
+		LatestBlockHeight   string `json:"latest_block_height"`
+		LatestBlockTime     string `json:"latest_block_time"`
+		EarliestBlockHash   string `json:"earliest_block_hash"`
+		EarliestAppHash     string `json:"earliest_app_hash"`
+		EarliestBlockHeight string `json:"earliest_block_height"`
+		EarliestBlockTime   string `json:"earliest_block_time"`
+		CatchingUp          bool   `json:"catching_up"`
+	}
 
-type ValidatorInfo struct {
-	Address     string `json:"address"`
-	PubKey      PubKey `json:"pub_key"`
-	VotingPower string `json:"voting_power"`
-}
-type PubKey struct {
-	Type  string `json:"type"`
-	Value string `json:"value"`
-}
+	ValidatorInfo struct {
+		Address     string `json:"address"`
+		PubKey      PubKey `json:"pub_key"`
+		VotingPower string `json:"voting_power"`
+	}
+	PubKey struct {
+		Type  string `json:"type"`
+		Value string `json:"value"`
+	}
+)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,14 +1,16 @@
 package types
 
-type Test struct {
-	Text string
-}
+type (
+	Test struct {
+		Text string
+	}
 
-type SekaidKey struct {
-	Address string `yaml:"address"`
-}
+	SekaidKey struct {
+		Address string `yaml:"address"`
+	}
 
-type AddressPermissions struct {
-	BlackList []int `json:"blacklist"`
-	WhiteList []int `json:"whitelist"`
-}
+	AddressPermissions struct {
+		BlackList []int `json:"blacklist"`
+		WhiteList []int `json:"whitelist"`
+	}
+)


### PR DESCRIPTION
A number of rules from `decorder` linter were applied:

- [x] (desired order: type,const,var,func)
- [x] multiple "type/const/var" declarations are not allowed; use parentheses instead