### PR TITLE
fixing all wrapping errors and capitalized messages

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,12 +48,12 @@ linters:
     - decorder
     - dogsled
     - errcheck
-  
+    - errname
+    - errorlint
+
   # enable:
   #   - cyclop
   #   - errchkjson
-  #   - errname
-  #   - errorlint
   #   - exhaustruct
   #   - exportloopref
   #   - forbidigo

--- a/internal/cli/deploy/cosign.go
+++ b/internal/cli/deploy/cosign.go
@@ -28,14 +28,14 @@ func installCosign(session *ssh.Session) error {
 func verifyCosignSignature(client *ssh.Client, pkgPath, sigPath string) error {
 	session, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("Failed to create SSH session: %v", err)
+		return fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	defer session.Close()
 
 	// Check if cosign is installed
 	if err := checkCosignInstalled(session); err != nil {
 		if installErr := installCosign(session); installErr != nil {
-			return fmt.Errorf("Failed to install Cosign: %v", installErr)
+			return fmt.Errorf("failed to install Cosign: %w", installErr)
 		}
 	}
 
@@ -45,7 +45,7 @@ func verifyCosignSignature(client *ssh.Client, pkgPath, sigPath string) error {
 	// Run the command on the remote host
 	log.Info("Verifying Cosign signature...")
 	if err := session.Run(cmdString); err != nil {
-		return fmt.Errorf("Failed to verify Cosign signature: %v", err)
+		return fmt.Errorf("failed to verify Cosign signature: %w", err)
 	}
 
 	return nil

--- a/internal/cli/deploy/deploy.go
+++ b/internal/cli/deploy/deploy.go
@@ -77,12 +77,12 @@ func Node() *cobra.Command {
 func createSSHClient(host, privKeyPath string) (*ssh.Client, error) {
 	key, err := ioutil.ReadFile(privKeyPath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read private key: %v", err)
+		return nil, fmt.Errorf("unable to read private key: %w", err)
 	}
 
 	signer, err := ssh.ParsePrivateKey(key)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse private key: %v", err)
+		return nil, fmt.Errorf("unable to parse private key: %w", err)
 	}
 
 	config := &ssh.ClientConfig{
@@ -95,7 +95,7 @@ func createSSHClient(host, privKeyPath string) (*ssh.Client, error) {
 
 	client, err := ssh.Dial("tcp", host+":22", config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial: %v", err)
+		return nil, fmt.Errorf("failed to dial: %w", err)
 	}
 
 	return client, nil
@@ -104,20 +104,20 @@ func createSSHClient(host, privKeyPath string) (*ssh.Client, error) {
 func forbidRootLogin(client *ssh.Client) error {
 	session, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create session: %v", err)
+		return fmt.Errorf("failed to create session: %w", err)
 	}
 	defer session.Close()
 
 	// Disable root login in sshd_config
 	_, err = session.Output("sed -i 's/^PermitRootLogin yes/PermitRootLogin no/g' /etc/ssh/sshd_config")
 	if err != nil {
-		return fmt.Errorf("failed to disable root login: %v", err)
+		return fmt.Errorf("failed to disable root login: %w", err)
 	}
 
 	// Restart SSH service to apply changes
 	_, err = session.Output("service ssh restart")
 	if err != nil {
-		return fmt.Errorf("failed to restart SSH service: %v", err)
+		return fmt.Errorf("failed to restart SSH service: %w", err)
 	}
 
 	return nil
@@ -127,7 +127,7 @@ func checkOSAndHardware(client *ssh.Client) (string, error) {
 	// Check the operating system
 	session, err := client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("failed to create session: %v", err)
+		return "", fmt.Errorf("failed to create session: %w", err)
 	}
 	defer session.Close()
 
@@ -137,7 +137,7 @@ func checkOSAndHardware(client *ssh.Client) (string, error) {
 	} else if output, err := session.Output("cmd /c ver"); err == nil {
 		os = string(output)
 	} else {
-		return "", fmt.Errorf("failed to determine operating system: %v", err)
+		return "", fmt.Errorf("failed to determine operating system: %w", err)
 	}
 
 	// Check hardware resources

--- a/internal/cli/deploy/docker.go
+++ b/internal/cli/deploy/docker.go
@@ -11,7 +11,7 @@ func installDocker(client *ssh.Client) error {
 	session, err := client.NewSession()
 	if err != nil {
 		log.Errorln("Failed to create session: ", err)
-		return fmt.Errorf("Failed to create session: %v", err)
+		return fmt.Errorf("failed to create session: %w", err)
 	}
 	defer session.Close()
 
@@ -27,7 +27,7 @@ func installDocker(client *ssh.Client) error {
 	_, err = session.Output(installCmd)
 	if err != nil {
 		log.Errorln("Failed to install Docker: ", err)
-		return fmt.Errorf("Failed to install Docker: %v", err)
+		return fmt.Errorf("failed to install Docker: %w", err)
 	}
 
 	return nil
@@ -37,7 +37,7 @@ func installDocker(client *ssh.Client) error {
 func checkDocker(client *ssh.Client) (string, error) {
 	session, err := client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("Failed to create SSH session: %v", err)
+		return "", fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	defer session.Close()
 
@@ -45,7 +45,7 @@ func checkDocker(client *ssh.Client) (string, error) {
 	log.Info("Checking if Docker is installed on the remote machine...")
 	dockerVersionBytes, err := session.Output("docker --version")
 	if err != nil {
-		return "", fmt.Errorf("Docker not found on the remote machine: %v", err)
+		return "", fmt.Errorf("docker not found on the remote machine: %w", err)
 	}
 
 	dockerVersion := strings.Trim(string(dockerVersionBytes), "\n")

--- a/internal/cli/deploy/keys.go
+++ b/internal/cli/deploy/keys.go
@@ -9,26 +9,26 @@ import (
 func installKeys(client *ssh.Client, privKey, pubKey string) error {
 	session, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("Failed to create session: %v", err)
+		return fmt.Errorf("failed to create session: %w", err)
 	}
 	defer session.Close()
 
 	// Create .ssh directory if it doesn't exist
 	_, err = session.Output("mkdir -p ~/.ssh")
 	if err != nil {
-		return fmt.Errorf("Failed to create .ssh directory: %v", err)
+		return fmt.Errorf("failed to create .ssh directory: %w", err)
 	}
 
 	// Write the public key to authorized_keys
 	_, err = session.Output(fmt.Sprintf("echo '%s' >> ~/.ssh/authorized_keys", pubKey))
 	if err != nil {
-		return fmt.Errorf("Failed to add public key to authorized_keys: %v", err)
+		return fmt.Errorf("failed to add public key to authorized_keys: %w", err)
 	}
 
 	// Set permissions for the .ssh directory and authorized_keys file
 	_, err = session.Output("chmod 700 ~/.ssh; chmod 600 ~/.ssh/authorized_keys")
 	if err != nil {
-		return fmt.Errorf("Failed to set permissions: %v", err)
+		return fmt.Errorf("failed to set permissions: %w", err)
 	}
 
 	return nil

--- a/internal/cli/deploy/package.go
+++ b/internal/cli/deploy/package.go
@@ -11,7 +11,7 @@ import (
 func checkPkg(client *ssh.Client, packageName string) (string, error) {
 	session, err := client.NewSession()
 	if err != nil {
-		return "", fmt.Errorf("Failed to create SSH session: %v", err)
+		return "", fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	defer session.Close()
 
@@ -21,7 +21,7 @@ func checkPkg(client *ssh.Client, packageName string) (string, error) {
 	log.Infof("Checking if package %s is installed on the remote machine...", packageName)
 	pkgVersionBytes, err := session.Output(cmdString)
 	if err != nil {
-		return "", fmt.Errorf("Package %s not found on the remote machine: %v", packageName, err)
+		return "", fmt.Errorf("package %s not found on the remote machine: %w", packageName, err)
 	}
 
 	pkgVersion := strings.Trim(string(pkgVersionBytes), "\n")
@@ -33,7 +33,7 @@ func installPkg(path string) error {
 	installCmd := exec.Command("dpkg", "-i", path)
 	output, err := installCmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("Failed to install package: %v", err)
+		return fmt.Errorf("failed to install package: %w", err)
 	}
 
 	log.Println(string(output))
@@ -43,7 +43,7 @@ func installPkg(path string) error {
 func downloadPkg(client *ssh.Client, url, path string) error {
 	session, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("Failed to create SSH session: %v", err)
+		return fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	defer session.Close()
 
@@ -52,7 +52,7 @@ func downloadPkg(client *ssh.Client, url, path string) error {
 
 	log.Infof("Downloading package from URL: %s", url)
 	if err := session.Run(cmdString); err != nil {
-		return fmt.Errorf("Failed to download package: %v", err)
+		return fmt.Errorf("failed to download package: %w", err)
 	}
 
 	return nil

--- a/internal/config/configFileController/configFileController.go
+++ b/internal/config/configFileController/configFileController.go
@@ -18,14 +18,14 @@ func ChangeConfigFile(cfg *config.KiraConfig) error {
 	filePath, configPath := configHandler.GetConfigFilePath()
 	okPath, err := osutils.CheckItPathExist(configPath)
 	if err != nil {
-		return fmt.Errorf("error while checking if %s exist, error:%s", configPath, err)
+		return fmt.Errorf("error while checking if %s exist, error:%w", configPath, err)
 	}
 	if !okPath {
 		return fmt.Errorf("config path <%s> does not exist", configPath)
 	}
 	err = configHandler.WriteConfigFile(filePath, cfg)
 	if err != nil {
-		return fmt.Errorf("error while writing cfg file: %s", err)
+		return fmt.Errorf("error while writing cfg file: %w", err)
 	}
 	return nil
 }
@@ -64,7 +64,7 @@ func ReadOrCreateConfig() (cfg *config.KiraConfig, err error) {
 	}
 	cfg, err = configHandler.ReadConfigFile(filePath)
 	if err != nil {
-		return cfg, fmt.Errorf("cannot read KiraConfig from file: <%s>, %s", filePath, err)
+		return cfg, fmt.Errorf("cannot read KiraConfig from file: <%s>, %w", filePath, err)
 	}
 	if cfg == nil {
 		return cfg, fmt.Errorf("cannot read config from: <%s>, kiraconfig is NIL", filePath)

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -567,7 +567,7 @@ func (dm *ContainerManager) StopProcessInsideContainer(ctx context.Context, proc
 	log.Printf("Checking if %s is running inside container", processName)
 	check, _, err := dm.CheckIfProcessIsRunningInContainer(ctx, processName, containerName)
 	if err != nil {
-		return fmt.Errorf("cant check if procces is running inside container, %s", err)
+		return fmt.Errorf("cant check if procces is running inside container, %w", err)
 	}
 	if !check {
 		log.Warnf("process <%s> is not running inside <%s> container\n", processName, containerName)
@@ -577,12 +577,12 @@ func (dm *ContainerManager) StopProcessInsideContainer(ctx context.Context, proc
 	out, err := dm.ExecCommandInContainer(ctx, containerName, []string{"pkill", fmt.Sprintf("-%v", codeToStopWith), processName})
 	if err != nil {
 		log.Errorf("cannot kill <%s> process inside <%s> container\nout: %s\nerr: %v\n", processName, containerName, string(out), err)
-		return fmt.Errorf("cannot kill <%s> process inside <%s> container\nout: %s\nerr: %s", processName, containerName, string(out), err)
+		return fmt.Errorf("cannot kill <%s> process inside <%s> container\nout: %s\nerr: %w", processName, containerName, string(out), err)
 	}
 
 	check, _, err = dm.CheckIfProcessIsRunningInContainer(ctx, processName, containerName)
 	if err != nil {
-		return fmt.Errorf("cant check if procces is running inside container, %s", err)
+		return fmt.Errorf("cant check if procces is running inside container, %w", err)
 	}
 	if check {
 		log.Errorf("Process <%s> is still running inside <%s> container\n", processName, containerName)

--- a/internal/firewall/firewallManager/firewallManager.go
+++ b/internal/firewall/firewallManager/firewallManager.go
@@ -80,7 +80,7 @@ func (fm *FirewallManager) SetUpFirewall(ctx context.Context) error {
 	log.Infof("Restarting docker service\n")
 	err := fm.DockerManager.RestartDockerService()
 	if err != nil {
-		return fmt.Errorf("cannot restart docker service: %s", err)
+		return fmt.Errorf("cannot restart docker service: %w", err)
 	}
 	log.Infof("Checking if docker is running\n")
 	err = fm.DockerManager.VerifyDockerInstallation(ctx)
@@ -214,7 +214,7 @@ func (fm *FirewallManager) SetUpFirewall(ctx context.Context) error {
 	log.Infof("Restarting docker service\n")
 	err = fm.DockerManager.RestartDockerService()
 	if err != nil {
-		return fmt.Errorf("cannot restart docker service: %s", err)
+		return fmt.Errorf("cannot restart docker service: %w", err)
 	}
 	return nil
 }
@@ -223,7 +223,7 @@ func (fm *FirewallManager) SetUpFirewall(ctx context.Context) error {
 func (fm *FirewallManager) ClostAllOpenedPorts(ctx context.Context) error {
 	_, ports, err := fm.FirewalldController.GetOpenedPorts(fm.FirewallConfig.ZoneName)
 	if err != nil {
-		return fmt.Errorf("cannot get opened ports: %s", err)
+		return fmt.Errorf("cannot get opened ports: %w", err)
 	}
 
 	var portsToClose []types.Port
@@ -231,19 +231,19 @@ func (fm *FirewallManager) ClostAllOpenedPorts(ctx context.Context) error {
 	for _, p := range ports {
 		port, err := fm.FirewallHandler.ConvertFirewalldPortToKM2Port(p)
 		if err != nil {
-			return fmt.Errorf("convert port: %s", err)
+			return fmt.Errorf("convert port: %w", err)
 		}
 		portsToClose = append(portsToClose, port)
 	}
 
 	err = fm.FirewallHandler.CheckPorts(portsToClose)
 	if err != nil {
-		return fmt.Errorf("cannot while checking ports are valid: %s", err)
+		return fmt.Errorf("cannot while checking ports are valid: %w", err)
 	}
 
 	err = fm.FirewallHandler.ClosePorts(portsToClose, fm.FirewallConfig.ZoneName)
 	if err != nil {
-		return fmt.Errorf("cannot close ports: %s", err)
+		return fmt.Errorf("cannot close ports: %w", err)
 	}
 
 	o, err := fm.FirewalldController.ReloadFirewall()
@@ -258,11 +258,11 @@ func (fm *FirewallManager) OpenConfigPorts(ctx context.Context) error {
 	portsToOpen := fm.FirewallConfig.PortsToOpen
 	err := fm.FirewallHandler.CheckPorts(portsToOpen)
 	if err != nil {
-		return fmt.Errorf("cannot while checking ports are valid: %s", err)
+		return fmt.Errorf("cannot while checking ports are valid: %w", err)
 	}
 	err = fm.FirewallHandler.OpenPorts(portsToOpen, fm.FirewallConfig.ZoneName)
 	if err != nil {
-		return fmt.Errorf("cannot open ports: %s", err)
+		return fmt.Errorf("cannot open ports: %w", err)
 	}
 	o, err := fm.FirewalldController.ReloadFirewall()
 	if err != nil {

--- a/internal/manager/cli/commands/firewall/blacklist/blacklist.go
+++ b/internal/manager/cli/commands/firewall/blacklist/blacklist.go
@@ -60,20 +60,20 @@ func Blacklist() *cobra.Command {
 func validateFlags(cmd *cobra.Command) error {
 	ip, err := cmd.Flags().GetString(ipFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving '%s' flag: %s", ipFlag, err)
+		return fmt.Errorf("error retrieving '%s' flag: %w", ipFlag, err)
 	}
 	check, err := osutils.CheckIfIPIsValid(ip)
 	if err != nil || !check {
-		return fmt.Errorf("cannot parse ip <%v>: %s", ip, err)
+		return fmt.Errorf("cannot parse ip <%v>: %w", ip, err)
 	}
 
 	add, err := cmd.Flags().GetBool("add")
 	if err != nil {
-		return fmt.Errorf("error retrieving '%s' flag: %s", addingFlag, err)
+		return fmt.Errorf("error retrieving '%s' flag: %w", addingFlag, err)
 	}
 	remove, err := cmd.Flags().GetBool("remove")
 	if err != nil {
-		return fmt.Errorf("error retrieving '%s' flag: %s", removingFlag, err)
+		return fmt.Errorf("error retrieving '%s' flag: %w", removingFlag, err)
 	}
 
 	if add && remove {

--- a/internal/manager/cli/commands/firewall/closePort/closePort.go
+++ b/internal/manager/cli/commands/firewall/closePort/closePort.go
@@ -57,16 +57,16 @@ func ClosePort() *cobra.Command {
 func validateFlags(cmd *cobra.Command) error {
 	portToClose, err := cmd.Flags().GetString(portFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving '%s' flag: %s", portFlag, err)
+		return fmt.Errorf("error retrieving '%s' flag: %w", portFlag, err)
 	}
 	check, err := osutils.CheckIfPortIsValid(portToClose)
 	if err != nil || !check {
-		return fmt.Errorf("cannot parse port <%v>: %s", portToClose, err)
+		return fmt.Errorf("cannot parse port <%v>: %w", portToClose, err)
 	}
 
 	portType, err := cmd.Flags().GetString(typeOfIPFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving '%s' flag: %s", typeOfIPFlag, err)
+		return fmt.Errorf("error retrieving '%s' flag: %w", typeOfIPFlag, err)
 	}
 	if portType != "tcp" && portType != "udp" {
 		return fmt.Errorf("wrong port type: <%s>, can only be <tcp> or <udp>", portType)

--- a/internal/manager/cli/commands/firewall/openPort/openPort.go
+++ b/internal/manager/cli/commands/firewall/openPort/openPort.go
@@ -57,16 +57,16 @@ func OpenPort() *cobra.Command {
 func validateFlags(cmd *cobra.Command) error {
 	portToOpen, err := cmd.Flags().GetString(portFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving '%s' flag: %s", portFlag, err)
+		return fmt.Errorf("error retrieving '%s' flag: %w", portFlag, err)
 	}
 	check, err := osutils.CheckIfPortIsValid(portToOpen)
 	if err != nil || !check {
-		return fmt.Errorf("cannot parse port <%v>: %s", portToOpen, err)
+		return fmt.Errorf("cannot parse port <%v>: %w", portToOpen, err)
 	}
 
 	portType, err := cmd.Flags().GetString(typeOfIPFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving '%s' flag: %s", typeOfIPFlag, err)
+		return fmt.Errorf("error retrieving '%s' flag: %w", typeOfIPFlag, err)
 	}
 	if portType != "tcp" && portType != "udp" {
 		return fmt.Errorf("wrong port type: <%s>, can only be <tcp> or <udp>", portType)

--- a/internal/manager/cli/commands/firewall/whitelist/whitelist.go
+++ b/internal/manager/cli/commands/firewall/whitelist/whitelist.go
@@ -60,20 +60,20 @@ func Whitelist() *cobra.Command {
 func validateFlags(cmd *cobra.Command) error {
 	ip, err := cmd.Flags().GetString(ipFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving '%s' flag: %s", ipFlag, err)
+		return fmt.Errorf("error retrieving '%s' flag: %w", ipFlag, err)
 	}
 	check, err := osutils.CheckIfIPIsValid(ip)
 	if err != nil || !check {
-		return fmt.Errorf("cannot parse ip <%v>: %s", ip, err)
+		return fmt.Errorf("cannot parse ip <%v>: %w", ip, err)
 	}
 
 	add, err := cmd.Flags().GetBool(addingFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving '%s' flag: %s", addingFlag, err)
+		return fmt.Errorf("error retrieving '%s' flag: %w", addingFlag, err)
 	}
 	remove, err := cmd.Flags().GetBool(removingFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving '%s' flag: %s", removingFlag, err)
+		return fmt.Errorf("error retrieving '%s' flag: %w", removingFlag, err)
 	}
 
 	if add && remove {

--- a/internal/manager/cli/commands/init/join/join.go
+++ b/internal/manager/cli/commands/init/join/join.go
@@ -81,7 +81,7 @@ func Join() *cobra.Command {
 func validateFlags(cmd *cobra.Command) error {
 	ip, err := cmd.Flags().GetString("ip")
 	if err != nil {
-		return fmt.Errorf("error retrieving 'ip' flag: %s", err)
+		return fmt.Errorf("error retrieving 'ip' flag: %w", err)
 	}
 	if !isValidIP(ip) {
 		return fmt.Errorf("'%s' is not a valid IP address", ip)
@@ -89,7 +89,7 @@ func validateFlags(cmd *cobra.Command) error {
 
 	interxPort, err := cmd.Flags().GetString("interx-port")
 	if err != nil {
-		return fmt.Errorf("error retrieving 'interx-port' flag: %s", err)
+		return fmt.Errorf("error retrieving 'interx-port' flag: %w", err)
 	}
 	if !isValidPort(interxPort) {
 		return fmt.Errorf("'%s' is not a valid Interx port", interxPort)
@@ -97,7 +97,7 @@ func validateFlags(cmd *cobra.Command) error {
 
 	rpcPort, err := cmd.Flags().GetString("rpc-port")
 	if err != nil {
-		return fmt.Errorf("error retrieving 'rpc-port' flag: %s", err)
+		return fmt.Errorf("error retrieving 'rpc-port' flag: %w", err)
 	}
 	if !isValidPort(rpcPort) {
 		return fmt.Errorf("'%s' is not a valid Sekaid RPC port", rpcPort)
@@ -105,7 +105,7 @@ func validateFlags(cmd *cobra.Command) error {
 
 	p2pPort, err := cmd.Flags().GetString("p2p-port")
 	if err != nil {
-		return fmt.Errorf("error retrieving 'p2p-port' flag: %s", err)
+		return fmt.Errorf("error retrieving 'p2p-port' flag: %w", err)
 	}
 	if !isValidPort(p2pPort) {
 		return fmt.Errorf("'%s' is not a valid Sekaid P2P port", p2pPort)
@@ -113,11 +113,11 @@ func validateFlags(cmd *cobra.Command) error {
 
 	_, err = cmd.Flags().GetString(sekaiVersionFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving %s flag: %s", sekaiVersionFlag, err)
+		return fmt.Errorf("error retrieving %s flag: %w", sekaiVersionFlag, err)
 	}
 	_, err = cmd.Flags().GetString(interxVersionFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving %s flag: %s", interxVersionFlag, err)
+		return fmt.Errorf("error retrieving %s flag: %w", interxVersionFlag, err)
 	}
 	return nil
 }

--- a/internal/manager/cli/commands/init/new/new.go
+++ b/internal/manager/cli/commands/init/new/new.go
@@ -59,11 +59,11 @@ func New() *cobra.Command {
 func validateFlags(cmd *cobra.Command) error {
 	sekaiVersion, err := cmd.Flags().GetString(sekaiVersionFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving <%s> flag: %s", sekaiVersion, err)
+		return fmt.Errorf("error retrieving <%s> flag: %w", sekaiVersion, err)
 	}
 	interxVersion, err := cmd.Flags().GetString(interxVersionFlag)
 	if err != nil {
-		return fmt.Errorf("error retrieving <%s> flag: %s", interxVersion, err)
+		return fmt.Errorf("error retrieving <%s> flag: %w", interxVersion, err)
 	}
 	return nil
 }

--- a/internal/manager/cli/commands/maintenance/mainteance.go
+++ b/internal/manager/cli/commands/maintenance/mainteance.go
@@ -80,13 +80,13 @@ func mainMaitenance(cmd *cobra.Command) error {
 	log.Debugln(pause, unpause, activate, status)
 	kiraCfg, err := configFileController.ReadOrCreateConfig()
 	if err != nil {
-		return fmt.Errorf("error while geting kira manager config: %s", err)
+		return fmt.Errorf("error while geting kira manager config: %w", err)
 	}
 	log.Debugf("kira manager cfg: %+v", kiraCfg)
 	ctx := context.Background()
 	cm, err := docker.NewTestContainerManager()
 	if err != nil {
-		return fmt.Errorf("error while geting containerManager: %s", err)
+		return fmt.Errorf("error while geting containerManager: %w", err)
 	}
 
 	switch {

--- a/internal/manager/utils/mnemonicController.go
+++ b/internal/manager/utils/mnemonicController.go
@@ -24,13 +24,14 @@ func (h *HelperManager) ReadMnemonicsFromFile(pathToFile string) (mastermnemonic
 	if check {
 		log.Println("path exist, trying to read mnemonic from mnemonics.env file")
 		if err := godotenv.Load(pathToFile); err != nil {
-			err = fmt.Errorf("error loading .env file: %v", err)
+			err = fmt.Errorf("error loading .env file: %w", err)
 			return mastermnemonic, err
 		}
 		// Retrieve the MASTER_MNEMONIC value
-		mastermnemonic = os.Getenv("MASTER_MNEMONIC")
+		const masterMnemonicEnv = "MASTER_MNEMONIC"
+		mastermnemonic = os.Getenv(masterMnemonicEnv)
 		if mastermnemonic == "" {
-			err = fmt.Errorf("MASTER_MNEMONIC not found")
+			err = fmt.Errorf("env variable '%s' not found", masterMnemonicEnv)
 			return mastermnemonic, err
 		} else {
 			log.Debugln("MASTER_MNEMONIC:", mastermnemonic)
@@ -90,11 +91,11 @@ func (h *HelperManager) SetSekaidKeys(ctx context.Context) error {
 	sekaidConfigFolder := h.config.SekaidHome + "/config"
 	_, err := h.containerManager.ExecCommandInContainer(ctx, h.config.SekaidContainerName, []string{"bash", "-c", fmt.Sprintf(`mkdir %s`, h.config.SekaidHome)})
 	if err != nil {
-		return fmt.Errorf("unable to create <%s> folder, err: %s", h.config.SekaidHome, err)
+		return fmt.Errorf("unable to create <%s> folder, err: %w", h.config.SekaidHome, err)
 	}
 	_, err = h.containerManager.ExecCommandInContainer(ctx, h.config.SekaidContainerName, []string{"bash", "-c", fmt.Sprintf(`mkdir %s`, sekaidConfigFolder)})
 	if err != nil {
-		return fmt.Errorf("unable to create <%s> folder, err: %s", sekaidConfigFolder, err)
+		return fmt.Errorf("unable to create <%s> folder, err: %w", sekaidConfigFolder, err)
 	}
 	err = h.containerManager.SendFileToContainer(ctx, h.config.SecretsFolder+"/priv_validator_key.json", sekaidConfigFolder, h.config.SekaidContainerName)
 	if err != nil {
@@ -129,16 +130,16 @@ func (h *HelperManager) SetEmptyValidatorState(ctx context.Context) error {
 	tmpFilePath := "/tmp/priv_validator_state.json"
 	err := osutils.CreateFileWithData(tmpFilePath, []byte(emptyState))
 	if err != nil {
-		return fmt.Errorf("unable to create file <%s>, error: %s", tmpFilePath, err)
+		return fmt.Errorf("unable to create file <%s>, error: %w", tmpFilePath, err)
 	}
 	sekaidDataFoder := h.config.SekaidHome + "/data"
 	_, err = h.containerManager.ExecCommandInContainer(ctx, h.config.SekaidContainerName, []string{"bash", "-c", fmt.Sprintf(`mkdir %s`, sekaidDataFoder)})
 	if err != nil {
-		return fmt.Errorf("unable to create folder <%s>, error: %s", sekaidDataFoder, err)
+		return fmt.Errorf("unable to create folder <%s>, error: %w", sekaidDataFoder, err)
 	}
 	err = h.containerManager.SendFileToContainer(ctx, tmpFilePath, sekaidDataFoder, h.config.SekaidContainerName)
 	if err != nil {
-		return fmt.Errorf("cannot send %s to container, err: %s", tmpFilePath, err)
+		return fmt.Errorf("cannot send %s to container, err: %w", tmpFilePath, err)
 	}
 	return nil
 }

--- a/internal/manager/utils/utils.go
+++ b/internal/manager/utils/utils.go
@@ -109,7 +109,7 @@ func (h *HelperManager) getBlockHeight(ctx context.Context) (string, error) {
 	cmd := "sekaid status"
 	statusOutput, err := h.containerManager.ExecCommandInContainer(ctx, h.config.SekaidContainerName, []string{"bash", "-c", cmd})
 	if err != nil {
-		return "", fmt.Errorf("getting '%s' error: %s", cmd, err)
+		return "", fmt.Errorf("getting '%s' error: %w", cmd, err)
 	}
 
 	var status struct { // anon structure which represents the partial response from `sekaid status`
@@ -154,7 +154,7 @@ func (h *HelperManager) GivePermissionToAddress(ctx context.Context, permissionT
 	err = h.AwaitNextBlock(ctx, h.config.TimeBetweenBlocks)
 	if err != nil {
 		log.Errorf("Awaiting error: %s", err)
-		return fmt.Errorf("awaiting error: %s", err)
+		return fmt.Errorf("awaiting error: %w", err)
 	}
 
 	txData, err := h.GetTxQuery(ctx, data.Txhash)
@@ -324,7 +324,7 @@ func (h *HelperManager) UpsertIdentityRecord(ctx context.Context, address, accou
 	err = h.AwaitNextBlock(ctx, h.config.TimeBetweenBlocks)
 	if err != nil {
 		log.Errorf("Awaiting error: %s", err)
-		return fmt.Errorf("awaiting error: %s", err)
+		return fmt.Errorf("awaiting error: %w", err)
 	}
 
 	txData, err := h.GetTxQuery(ctx, data.Txhash)

--- a/internal/monitoring/monitoring.go
+++ b/internal/monitoring/monitoring.go
@@ -60,7 +60,7 @@ func doHTTPGetQuery(ctx context.Context, httpClient *http.Client, interxPort str
 
 	if resp.StatusCode != http.StatusOK {
 		log.Errorf("HTTP request failed with status: %d", resp.StatusCode)
-		return fmt.Errorf("HTTP request failed with status: %d", resp.StatusCode)
+		return fmt.Errorf("http request failed with status: %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/internal/osutils/osutils.go
+++ b/internal/osutils/osutils.go
@@ -177,13 +177,13 @@ func hasInternetAccess(ifaceName string) bool {
 func CreateFileWithData(filePath string, data []byte) error {
 	file, err := os.Create(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to create file: %v", err)
+		return fmt.Errorf("failed to create file: %w", err)
 	}
 	defer file.Close()
 
 	_, err = file.Write(data)
 	if err != nil {
-		return fmt.Errorf("failed to write data to file: %v", err)
+		return fmt.Errorf("failed to write data to file: %w", err)
 	}
 
 	return nil

--- a/internal/systemd/manager.go
+++ b/internal/systemd/manager.go
@@ -39,7 +39,7 @@ func (s *ServiceManager) Close() {
 func (s *ServiceManager) CheckServiceExists(ctx context.Context) (bool, error) {
 	units, err := s.connection.ListUnitsByNamesContext(ctx, []string{s.serviceName})
 	if err != nil {
-		return false, fmt.Errorf("failed to get list of services: %s", err)
+		return false, fmt.Errorf("failed to get list of services: %w", err)
 	}
 
 	for _, unit := range units {
@@ -57,7 +57,7 @@ func (s *ServiceManager) CheckServiceExists(ctx context.Context) (bool, error) {
 func (s *ServiceManager) GetServiceStatus(ctx context.Context) (string, error) {
 	unitStates, err := s.connection.ListUnitsByNamesContext(ctx, []string{s.serviceName})
 	if err != nil {
-		return "", fmt.Errorf("failed to get list of units: %s", err)
+		return "", fmt.Errorf("failed to get list of units: %w", err)
 	}
 
 	unitStatus, err := s.connection.GetUnitPropertiesContext(ctx, s.serviceName)
@@ -67,7 +67,7 @@ func (s *ServiceManager) GetServiceStatus(ctx context.Context) (string, error) {
 
 	active, ok := unitStatus["ActiveState"].(string)
 	if !ok {
-		return "", fmt.Errorf("failed to determine unit file state: %s", err)
+		return "", fmt.Errorf("failed to determine unit file state: %w", err)
 	}
 
 	if active != unitStates[0].ActiveState {


### PR DESCRIPTION
`errorlint`'s issues were resolved:

- [x] Wrapping errors: `%s / %v => %w`
- [x] Capitalized error messages were lowercased 