### PR TITLE
Linter/forbidigo

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -52,11 +52,11 @@ linters:
     - errorlint
     - errchkjson
     - exportloopref
+    - forbidigo
 
   # enable:
   #   - cyclop
   #   - exhaustruct
-  #   - forbidigo
   #   - forcetypeassert
   #   - funlen
   #   - gochecknoglobals
@@ -171,6 +171,15 @@ linters-settings:
     # Check for plain error comparisons.
     comparison: true
   
+  forbidigo:
+    forbid:
+      - p: "^fmt\\.Print(|f|ln)$"
+        msg: "Using fmt for logging is forbidden"
+      - p: "^log\\.Print(|f|ln)$"
+        msg: "Using log.Print statements is forbidden - specify log level directly!"
+      - p: "^(print|println)$"
+        msg: "Do NOT use built-in methods for output"
+
   funlen:
     # Checks the number of lines in a function.
     lines: 40

--- a/internal/adapters/github.go
+++ b/internal/adapters/github.go
@@ -132,7 +132,7 @@ func (gh *gitHubAdapter) getLatestRelease(ctx context.Context, owner, repo strin
 func (gh *gitHubAdapter) downloadBinaryFromRepo(ctx context.Context, owner, repo, binaryName, tag string) {
 	var release *github.RepositoryRelease
 	var err error
-	log.Printf("downloading %s from %s/%s, tag:%s\n", binaryName, owner, repo, tag)
+	log.Infof("Downloading '%s' from '%s/%s', tag: %s", binaryName, owner, repo, tag)
 	switch tag {
 	case "latest":
 		release, _, err = gh.client.Repositories.GetLatestRelease(ctx, owner, repo)

--- a/internal/cli/deploy/deploy.go
+++ b/internal/cli/deploy/deploy.go
@@ -62,7 +62,7 @@ func Node() *cobra.Command {
 			if err != nil {
 				log.Fatalf("Failed to check OS and hardware: %v", err)
 			}
-			log.Println(osAndHardwareInfo)
+			log.Infof("OS and Hardware info: %s", osAndHardwareInfo)
 		},
 	}
 	for _, node := range nodes {
@@ -165,7 +165,7 @@ func checkOSAndHardware(client *ssh.Client) (string, error) {
 			defer wg.Done()
 			session, err := client.NewSession()
 			if err != nil {
-				log.Printf("Failed to create session: %v", err)
+				log.Errorf("Failed to create session: %s", err)
 				return
 			}
 			defer session.Close()
@@ -174,7 +174,7 @@ func checkOSAndHardware(client *ssh.Client) (string, error) {
 				hardwareInfo += string(output) + "\n"
 				mutex.Unlock()
 			} else {
-				log.Printf("Failed to execute command %s: %v", command, err)
+				log.Errorf("Failed to execute command %s: %s", command, err)
 			}
 		}(cmd)
 	}

--- a/internal/cli/deploy/docker.go
+++ b/internal/cli/deploy/docker.go
@@ -18,7 +18,7 @@ func installDocker(client *ssh.Client) error {
 	// Check if Docker is already installed
 	_, err = session.Output("docker -v")
 	if err == nil {
-		log.Println("Docker is already installed")
+		log.Info("Docker is already installed")
 		return nil
 	}
 

--- a/internal/cli/deploy/package.go
+++ b/internal/cli/deploy/package.go
@@ -31,12 +31,13 @@ func checkPkg(client *ssh.Client, packageName string) (string, error) {
 
 func installPkg(path string) error {
 	installCmd := exec.Command("dpkg", "-i", path)
+	log.Infof("Executing command: %s", installCmd)
 	output, err := installCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to install package: %w", err)
 	}
 
-	log.Println(string(output))
+	log.Infof("Output of command: %s", string(output))
 	return nil
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -131,7 +131,7 @@ func (dm *DockerManager) CheckOrCreateNetwork(ctx context.Context, networkName s
 
 	for _, network := range networkList {
 		if network.Name == networkName {
-			log.Printf("Network '%s' already exists", networkName)
+			log.Infof("Network '%s' already exists", networkName)
 			return nil
 		}
 	}

--- a/internal/maintenance/mainteance.go
+++ b/internal/maintenance/mainteance.go
@@ -40,7 +40,7 @@ func GetValidatorStatus(ctx context.Context, cfg *config.KiraConfig, cm *docker.
 // PauseValidator is geting validator status, if status IS ACTIVE running `sekaid tx customslashing pause` inside sekaid container.
 // Then checking if transaction of validator pausing was executed inside blockchain, if does -  again checking for validator status
 func PauseValidator(ctx context.Context, cfg *config.KiraConfig, cm *docker.ContainerManager) error {
-	log.Printf("Pausing validator\n")
+	log.Info("Pausing validator")
 	nodeStatus, err := GetValidatorStatus(ctx, cfg, cm)
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func PauseValidator(ctx context.Context, cfg *config.KiraConfig, cm *docker.Cont
 // UnpauseValidator is geting validator status, if status IS PAUSED running `sekaid tx customslashing unpause` inside sekaid container.
 // Then checking if transaction of validator unpausing was executed inside blockchain, if does -  again checking for validator status
 func UnpauseValidator(ctx context.Context, cfg *config.KiraConfig, cm *docker.ContainerManager) error {
-	log.Printf("Unpausing validator\n")
+	log.Info("Unpausing validator")
 	nodeStatus, err := GetValidatorStatus(ctx, cfg, cm)
 	if err != nil {
 		return err
@@ -145,7 +145,7 @@ func UnpauseValidator(ctx context.Context, cfg *config.KiraConfig, cm *docker.Co
 // ActivateValidator is geting validator status, if status IS INACTIVE running `sekaid tx customslashing activate` inside sekaid container.
 // Then checking if transaction of validator activating was executed inside blockchain
 func ActivateValidator(ctx context.Context, cfg *config.KiraConfig, cm *docker.ContainerManager) error {
-	log.Printf("Activating validator\n")
+	log.Info("Activating validator")
 	nodeStatus, err := GetValidatorStatus(ctx, cfg, cm)
 	if err != nil {
 		return err

--- a/internal/manager/cli/commands/firewall/blacklist/blacklist.go
+++ b/internal/manager/cli/commands/firewall/blacklist/blacklist.go
@@ -87,7 +87,6 @@ func validateFlags(cmd *cobra.Command) error {
 }
 
 func mainBlacklist(cmd *cobra.Command) {
-	log.Println("mainBlacklist")
 	ip, err := cmd.Flags().GetString("ip")
 	errors.HandleFatalErr("cannot Get blacklist-ip", err)
 	ok, err := osutils.CheckIfIPIsValid(ip)

--- a/internal/manager/cli/commands/firewall/closePort/closePort.go
+++ b/internal/manager/cli/commands/firewall/closePort/closePort.go
@@ -85,7 +85,7 @@ func mainClosePort(cmd *cobra.Command) {
 	errors.HandleFatalErr(fmt.Sprintf("cannot get '%s' flag", typeOfIPFlag), err)
 
 	fc := firewallController.NewFireWalldController("validator")
-	log.Printf("Adding %s port with %s type\n", port.Port, port.Type)
+	log.Infof("Adding %s port with %s type\n", port.Port, port.Type)
 	_, err = fc.ClosePort(port, fc.ZoneName)
 	errors.HandleFatalErr(fmt.Sprintf("error while closing port %v", port), err)
 

--- a/internal/manager/cli/commands/firewall/firewall.go
+++ b/internal/manager/cli/commands/firewall/firewall.go
@@ -63,7 +63,7 @@ func mainFirewall(cmd *cobra.Command) {
 	kiraCfg, err := configFileController.ReadOrCreateConfig()
 	errors.HandleFatalErr("Error while reading cfg file", err)
 
-	log.Println("validating flags")
+	log.Info("Validating flags")
 
 	openPorts, err := cmd.Flags().GetBool("open-ports")
 	errors.HandleFatalErr("cannot parse flag", err)

--- a/internal/manager/cli/commands/firewall/openPort/openPort.go
+++ b/internal/manager/cli/commands/firewall/openPort/openPort.go
@@ -85,7 +85,7 @@ func mainOpenPort(cmd *cobra.Command) {
 	errors.HandleFatalErr("cannot get type flag", err)
 
 	fc := firewallController.NewFireWalldController("validator")
-	log.Printf("Adding %s port with %s type\n", port.Port, port.Type)
+	log.Infof("Adding %s port with %s type\n", port.Port, port.Type)
 	_, err = fc.OpenPort(port, fc.ZoneName)
 	errors.HandleFatalErr(fmt.Sprintf("error while opening port %v", port), err)
 

--- a/internal/manager/cli/commands/firewall/whitelist/whitelist.go
+++ b/internal/manager/cli/commands/firewall/whitelist/whitelist.go
@@ -87,7 +87,6 @@ func validateFlags(cmd *cobra.Command) error {
 }
 
 func mainWhitelist(cmd *cobra.Command) {
-	log.Println("mainWhitelist")
 	ip, err := cmd.Flags().GetString(ipFlag)
 	errors.HandleFatalErr("cannot Get whitelist-ip", err)
 	ok, err := osutils.CheckIfIPIsValid(ip)

--- a/internal/manager/cli/commands/init/join/join.go
+++ b/internal/manager/cli/commands/init/join/join.go
@@ -233,8 +233,10 @@ func mainJoin(cmd *cobra.Command) {
 	errors.HandleFatalErr("Can't create new 'sekai' manager instance", err)
 	sekaiManager.MustInitJoiner(ctx, genesis)
 	sekaiManager.MustRunSekaid(ctx)
-	log.Printf("Waiting for %v\n", cfg.TimeBetweenBlocks)
+
+	log.Infof("Waiting for %v\n", cfg.TimeBetweenBlocks)
 	time.Sleep(cfg.TimeBetweenBlocks + time.Second)
+
 	interxManager, err := manager.NewInterxManager(containerManager, cfg)
 	errors.HandleFatalErr("Can't create new 'interx' manager instance", err)
 	interxManager.MustInitInterx(ctx)

--- a/internal/manager/cli/commands/init/new/new.go
+++ b/internal/manager/cli/commands/init/new/new.go
@@ -129,8 +129,10 @@ func mainNew(cmd *cobra.Command) {
 	errors.HandleFatalErr("Error creating new 'sekai' manager instance", err)
 	sekaiManager.MustInitNew(ctx)
 	sekaiManager.MustRunSekaid(ctx)
-	log.Printf("Waiting for %v\n", cfg.TimeBetweenBlocks)
+
+	log.Infof("Waiting for %v\n", cfg.TimeBetweenBlocks)
 	time.Sleep(cfg.TimeBetweenBlocks + time.Second)
+
 	interxManager, err := manager.NewInterxManager(containerManager, cfg)
 	errors.HandleFatalErr("Error creating new 'interx' manager instance:", err)
 	interxManager.MustInitInterx(ctx)

--- a/internal/manager/cli/commands/maintenance/mainteance.go
+++ b/internal/manager/cli/commands/maintenance/mainteance.go
@@ -111,7 +111,7 @@ func mainMaitenance(cmd *cobra.Command) error {
 			return err
 		}
 		// log.Infof("Validator Status:\nStatus: %s\nStreak: %s\nRank: %s\n", valStatus.Status, valStatus.Streak, valStatus.Rank)
-		fmt.Printf("***Validator Status***\nStatus: %s\nStreak: %s\nRank: %s\n", valStatus.Status, valStatus.Streak, valStatus.Rank)
+		log.Infof("***Validator Status***\nStatus: %s\nStreak: %s\nRank: %s\n", valStatus.Status, valStatus.Streak, valStatus.Rank)
 		log.Debugf("valStatus: %+v\n", valStatus)
 	}
 	return nil

--- a/internal/manager/interx.go
+++ b/internal/manager/interx.go
@@ -128,7 +128,7 @@ func (i *InterxManager) applyNewConfigs(ctx context.Context, updates []config.Js
 			continue
 		}
 
-		log.Printf("(%s = %v) updated successfully\n", update.Key, update.Value)
+		log.Infof("(%s = %v) updated successfully\n", update.Key, update.Value)
 
 		configFileContent = newFileContent
 	}

--- a/internal/manager/sekaid.go
+++ b/internal/manager/sekaid.go
@@ -204,7 +204,7 @@ func (s *SekaidManager) applyNewConfig(ctx context.Context, configsToml []config
 			continue
 		}
 
-		log.Printf("Value ([%s] %s = %s) updated successfully\n", update.Tag, update.Name, update.Value)
+		log.Infof("Value ([%s] %s = %s) updated successfully\n", update.Tag, update.Name, update.Value)
 
 		config = newConfig
 	}
@@ -265,17 +265,17 @@ func (s *SekaidManager) ReadOrGenerateMasterMnemonic() error {
 		masterMnemonic, err = s.helper.ReadMnemonicsFromFile(s.config.SecretsFolder + "/mnemonics.env")
 
 		if masterMnemonic == "" || err != nil {
-			log.Printf("Coud not read master mnemonic from file, trying to generete new one \n%s\n", err)
+			log.Warningf("Could not read master mnemonic from file, trying to generate new one \n%s\n", err)
 			bip39mn, err := s.helper.GenerateMnemonic()
 			if err != nil {
 				return err
 			}
 			masterMnemonic = bip39mn.String()
 		} else {
-			log.Println("MASTER MNEMONIC WAS FOUND AND RESTORED")
+			log.Info("Master mnemonic was found and restored")
 		}
 	}
-	log.Debugf("MASTER MNEMONIC IS:\n%s\n", masterMnemonic)
+	log.Debugf("Master mnemonic is:\n%s\n", masterMnemonic)
 	s.config.MasterMnamonicSet, err = s.helper.GenerateMnemonicsFromMaster(string(masterMnemonic))
 	if err != nil {
 		return err
@@ -451,14 +451,14 @@ func (s *SekaidManager) postGenesisProposals(ctx context.Context) error {
 		types.PermVoteUpsertTokenAliasProposal,
 		types.PermVoteSoftwareUpgradeProposal,
 	}
-	log.Printf("Permissions to add: '%d' for: '%s'", permissions, address)
+	log.Infof("Permissions to add: '%d' for: '%s'", permissions, address)
 
 	// waiting 10 sec to first block to be propagated
 	log.Infof("Waiting for %0.0f seconds before first block be propagated", time.Duration.Seconds(s.config.TimeBetweenBlocks))
 	time.Sleep(s.config.TimeBetweenBlocks)
 
 	for _, perm := range permissions {
-		log.Printf("Adding permission: '%d'", perm)
+		log.Infof("Adding permission: '%d'", perm)
 
 		err = s.helper.GivePermissionToAddress(ctx, perm, address)
 		if err != nil {
@@ -466,7 +466,7 @@ func (s *SekaidManager) postGenesisProposals(ctx context.Context) error {
 			return fmt.Errorf("giving permission '%d' error: %w", perm, err)
 		}
 
-		log.Printf("Checking if '%s' address has '%d' permission", address, perm)
+		log.Infof("Checking if '%s' address has '%d' permission", address, perm)
 		check, err := s.helper.CheckAccountPermission(ctx, perm, address)
 		if err != nil {
 			log.Errorf("Checking account permission error: %s", err)

--- a/internal/manager/stop.go
+++ b/internal/manager/stop.go
@@ -11,20 +11,24 @@ import (
 
 var log = logging.Log
 
-// MustStopSekaid is stoping sekaid process with StopProcessInsideContainer func (signal code - 15) and stoping sekaid container
+// MustStopSekaid is stopping sekaid process with StopProcessInsideContainer func (signal code - 15) and stopping sekaid container
 func (s *SekaidManager) MustStopSekaid(ctx context.Context) {
 	err := s.containerManager.StopProcessInsideContainer(ctx, "sekaid", 15, s.config.SekaidContainerName)
-	errors.HandleFatalErr("Stoping sekaid bin in container", err)
-	log.Printf("Stoping <%s> container\n", s.config.SekaidContainerName)
+	errors.HandleFatalErr("Stopping sekaid bin in container", err)
+
+	// TODO change method for dockerManager method instead of Cli
+	log.Infof("Stopping <%s> container\n", s.config.SekaidContainerName)
 	err = s.dockerManager.Cli.ContainerStop(ctx, s.config.SekaidContainerName, container.StopOptions{})
 	errors.HandleFatalErr(fmt.Sprintf("cannot stop %s container", s.config.SekaidContainerName), err)
 }
 
-// MustStopInterx is stoping interx process with StopProcessInsideContainer func (signal code - 9) and stoping interx container
+// MustStopInterx is stopping interx process with StopProcessInsideContainer func (signal code - 9) and stopping interx container
 func (i *InterxManager) MustStopInterx(ctx context.Context) {
 	err := i.containerManager.StopProcessInsideContainer(ctx, interxProcessName, 9, i.config.InterxContainerName)
-	errors.HandleFatalErr("Stoping interx bin in container", err)
-	log.Printf("Stoping <%s> container\n", i.config.InterxContainerName)
+	errors.HandleFatalErr("Stopping interx bin in container", err)
+
+	// TODO change method for dockerManager method instead of Cli
+	log.Infof("Stopping <%s> container\n", i.config.InterxContainerName)
 	err = i.containerManager.Cli.ContainerStop(ctx, i.config.InterxContainerName, container.StopOptions{})
 	errors.HandleFatalErr(fmt.Sprintf("cannot stop %s container", i.config.InterxContainerName), err)
 }

--- a/internal/manager/utils/json.go
+++ b/internal/manager/utils/json.go
@@ -47,7 +47,7 @@ func setNested(m map[string]any, keys []string, value any) error {
 	}
 
 	log.Debugf("Found key: %s\n", keys[len(keys)-1])
-	log.Printf("Update old value '%v' -> new value '%v'\n", m[keys[len(keys)-1]], value)
+	log.Infof("Update old value '%v' -> new value '%v'\n", m[keys[len(keys)-1]], value)
 	m[keys[len(keys)-1]] = value
 	return nil
 }

--- a/internal/manager/utils/mnemonicController.go
+++ b/internal/manager/utils/mnemonicController.go
@@ -16,16 +16,16 @@ import (
 
 func (h *HelperManager) ReadMnemonicsFromFile(pathToFile string) (mastermnemonic string, err error) {
 	log := logging.Log
-	log.Println("checking if path exist: ", pathToFile)
+	log.Infof("Checking if path exist: %s", pathToFile)
 	check, err := osutils.CheckItPathExist(pathToFile)
 	if err != nil {
-		log.Printf("error while checkin path to %s, error: %s", pathToFile, err)
+		log.Errorf("Checking path to '%s', error: %s", pathToFile, err)
 	}
 	if check {
-		log.Println("path exist, trying to read mnemonic from mnemonics.env file")
+		log.Infof("Path exist, trying to read mnemonic from mnemonics.env file")
 		if err := godotenv.Load(pathToFile); err != nil {
 			err = fmt.Errorf("error loading .env file: %w", err)
-			return mastermnemonic, err
+			return "", err
 		}
 		// Retrieve the MASTER_MNEMONIC value
 		const masterMnemonicEnv = "MASTER_MNEMONIC"
@@ -54,19 +54,21 @@ func (h *HelperManager) GenerateMnemonicsFromMaster(masterMnemonic string) (*vlg
 		return &vlg.MasterMnemonicSet{}, err
 	}
 	str := fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n", mnemonicSet.SignerAddrMnemonic, mnemonicSet.ValidatorNodeMnemonic, mnemonicSet.ValidatorNodeId, mnemonicSet.ValidatorAddrMnemonic, mnemonicSet.ValidatorValMnemonic)
-	fmt.Println((str))
+	log.Infof("Master mnemonic:\n%s", str)
 	return &mnemonicSet, nil
 }
 
 func (h *HelperManager) MnemonicReader() (masterMnemonic string) {
 	log := logging.Log
-	fmt.Printf("\nENTER YOUR MASTER MNEMONIC:\n")
+	log.Infoln("ENTER YOUR MASTER MNEMONIC:")
 	// var input string
 	reader := bufio.NewReader(os.Stdin)
-	log.Println("Enter mnemonic: ")
+	//nolint:forbidigo // reading user input
+	fmt.Println("Enter mnemonic: ")
+
 	text, err := reader.ReadString('\n')
 	if err != nil {
-		fmt.Println("An error occurred:", err)
+		log.Errorf("An error occurred: %s", err)
 		return
 	}
 	mnemonicBytes := []byte(text)

--- a/internal/manager/utils/utils.go
+++ b/internal/manager/utils/utils.go
@@ -141,7 +141,7 @@ func (h *HelperManager) GivePermissionToAddress(ctx context.Context, permissionT
 		log.Errorf("Giving '%d' permission error. Command: '%s'. Error: %s", permissionToAdd, command, err)
 		return err
 	}
-	log.Printf("Permission '%d' is pushed to network for address '%s'", permissionToAdd, address)
+	log.Infof("Permission '%d' is pushed to network for address '%s'", permissionToAdd, address)
 
 	var data types.TxData
 	err = json.Unmarshal(out, &data)
@@ -201,7 +201,7 @@ func (h *HelperManager) CheckAccountPermission(ctx context.Context, permissionTo
 	log.Debugf("Checking account permission: %+v", perms)
 	for _, perm := range perms.WhiteList {
 		if permissionToCheck == perm {
-			log.Printf("Permission '%d' was found with '%s' address", permissionToCheck, address)
+			log.Infof("Permission '%d' was found with '%s' address", permissionToCheck, address)
 
 			return true, nil
 		}
@@ -233,7 +233,7 @@ func (h *HelperManager) GetAddressByName(ctx context.Context, addressName string
 		return "", err
 	}
 
-	log.Printf("Validator address: '%s'", key[0].Address)
+	log.Infof("Validator address: '%s'", key[0].Address)
 	return key[0].Address, nil
 }
 
@@ -347,7 +347,7 @@ func (h *HelperManager) getSekaidStatus() (*types.Status, error) {
 	log := logging.Log
 
 	url := fmt.Sprintf("http://localhost:%s/status", h.config.RpcPort)
-	log.Println(url)
+	log.Infof("URL: %s", url)
 	response, err := http.Get(url)
 	if err != nil {
 		log.Errorf("Failed to send GET request: %s", err)

--- a/internal/monitoring/hardware.go
+++ b/internal/monitoring/hardware.go
@@ -170,7 +170,7 @@ func getInterfacesIP() (map[string]string, error) {
 	for _, iface := range interfaces {
 		addrs, err := iface.Addrs()
 		if err != nil {
-			log.Println("Getting unicast interface addresses for a specific interface error:", err)
+			log.Errorf("Getting unicast interface addresses for a specific interface error: %s", err)
 			return nil, err
 		}
 

--- a/internal/systemd/manager.go
+++ b/internal/systemd/manager.go
@@ -21,7 +21,7 @@ var log = logging.Log
 func NewServiceManager(ctx context.Context, serviceName, mode string) (*ServiceManager, error) {
 	conn, err := dbus.NewWithContext(ctx)
 	if err != nil {
-		log.Printf("Failed to connect to D-Bus: %s", err)
+		log.Errorf("Failed to connect to D-Bus: %s", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
`forbidigo` is linter which forbids using specific things, for example:

- [x] Using `fmt` package for output
- [x] Using `log.Print`-like statements, we have to use Logging Level instead